### PR TITLE
Add compat layer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ winapi = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "0.2"
-security-framework = "0.1.2"
+security-framework = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Rust API currently looks like this:
 ```rust
 extern crate certitude;
 
-use certitude::os_x::validate_cert_chain;
+use certitude::platform::validate_cert_chain;
 
 fn example() {
     // Assume certs is a Vector of DER-encoded certificates.
@@ -27,7 +27,7 @@ fn example() {
 }
 ```
 
-In the future, the OS X and Windows implementations should be transparently switched in and out, such that a user of this library can transparently use a single API and have the appropriate platform-specific logic used directly, without their intervention.
+The OS X and Windows implementations are transparently switched in and out, such that a user of this library can use a single API and have the appropriate platform-specific logic used directly, without their intervention. This of course requires building against the correct target, but as long as the target is correctly specified the correct version of the code will be used.
 
 ## Work In Progress
 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ In the future, the OS X and Windows implementations should be transparently swit
 
 ## Work In Progress
 
-This is currently a very early beta, and I'm mostly investigating the feasibility of the approach. Currently the library only "supports" OS X as a valid certificate verification platform. The next target will be Windows: following that, I will investigate the feasibility of hooking into OpenSSL, though that's considered a strictly less important problem than sorting this out on Windows and OS X.
+This is currently a very early beta, and I'm mostly investigating the feasibility of the approach. Currently the library supports OS X and Windows as a valid certificate verification platform. I will investigate the feasibility of hooking into OpenSSL, though that's considered a strictly less important problem than sorting this out on Windows and OS X, as people using OpenSSL for their TLS will already have access to OpenSSL's native validation logic.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ macro_rules! fail_on_error {
     }
 }
 
+pub mod platform;
 #[cfg(windows)]
 pub mod windows;
 #[cfg(target_os = "macos")]
@@ -25,7 +26,7 @@ pub mod osx;
 
 #[cfg(test)]
 mod test {
-    use os_x::validate_cert_chain;
+    use platform::validate_cert_chain;
 
     fn certifi_chain() -> Vec<&'static[u8]> {
         let leaf = include_bytes!("../fixtures/certifi-leaf.crt");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate libc;
 
-#[cfg(macos)]
+#[cfg(target_os = "macos")]
 extern crate core_foundation;
-#[cfg(macos)]
+#[cfg(target_os = "macos")]
 extern crate security_framework;
 #[cfg(windows)]
 extern crate crypt32;
@@ -23,7 +23,6 @@ pub mod windows;
 #[cfg(macos)]
 pub mod os_x;
 
-#[cfg(macos)]
 #[cfg(test)]
 mod test {
     use os_x::validate_cert_chain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ macro_rules! fail_on_error {
 
 #[cfg(windows)]
 pub mod windows;
-#[cfg(macos)]
-pub mod os_x;
+#[cfg(target_os = "macos")]
+pub mod osx;
 
 #[cfg(test)]
 mod test {

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -1,29 +1,30 @@
-extern crate libc;
+use security_framework::certificate::SecCertificate;
+use security_framework::policy::SecPolicy;
+use security_framework::secure_transport::ProtocolSide;
+use security_framework::trust::SecTrust;
 
-#[cfg(macos)]
-extern crate core_foundation;
-#[cfg(macos)]
-extern crate security_framework;
-#[cfg(windows)]
-extern crate crypt32;
-#[cfg(windows)]
-extern crate winapi;
-
-macro_rules! fail_on_error {
-    ($e:expr) => {
-        match $e {
-            Ok(s) => s,
+pub fn validate_cert_chain(encoded_certs: Vec<&[u8]>, hostname: &str) -> bool {
+    let mut certs = Vec::new();
+    for encoded_cert in encoded_certs {
+        let cert = SecCertificate::from_der(encoded_cert);
+        match cert {
+            Ok(cert) => certs.push(cert),
             Err(_) => return false,
         }
     }
+
+    let ssl_policy = fail_on_error!(SecPolicy::for_ssl(ProtocolSide::Client, hostname));
+    let trust = fail_on_error!(SecTrust::create_with_certificates(&certs[..], &[ssl_policy]));
+
+    // Deliberately swallow errors here: any error is likely to do with the
+    // hostname or cert chain, and if those are invalid then by definition the
+    // cert does not validate.
+    match trust.evaluate() {
+        Ok(result) => result.success(),
+        Err(_) => false
+    }
 }
 
-#[cfg(windows)]
-pub mod windows;
-#[cfg(macos)]
-pub mod os_x;
-
-#[cfg(macos)]
 #[cfg(test)]
 mod test {
     use os_x::validate_cert_chain;

--- a/src/osx.rs
+++ b/src/osx.rs
@@ -27,7 +27,7 @@ pub fn validate_cert_chain(encoded_certs: Vec<&[u8]>, hostname: &str) -> bool {
 
 #[cfg(test)]
 mod test {
-    use os_x::validate_cert_chain;
+    use osx::validate_cert_chain;
 
     fn certifi_chain() -> Vec<&'static[u8]> {
         let leaf = include_bytes!("../fixtures/certifi-leaf.crt");

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,10 @@
+// Provides the abstraction layer: calls into the appropriate platform-native functions.
+#[cfg(target_os = "macos")]
+use osx::validate_cert_chain as backend;
+#[cfg(windows)]
+use windows::validate_cert_chain as backend;
+
+/// Validate a chain of certificates.
+pub fn validate_cert_chain(encoded_certs: Vec<&[u8]>, hostname: &str) -> bool {
+    backend(encoded_certs, hostname)
+}


### PR DESCRIPTION
This layer allows people to import just one namespace and automatically get the right functions.
