### PR TITLE
Don't trust when something terrible goes wrong, do trust explicitly trusted roots.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,14 @@ platform:
 environment:
   matrix:
     - TOOLCHAIN_VERSION: 14.0
-      RUST: 1.5.0
+      RUST: 1.9.0
     - TOOLCHAIN_VERSION: 14.0
       RUST: beta
     - TOOLCHAIN_VERSION: 14.0
       RUST: nightly
 
     - TOOLCHAIN_VERSION: 12.0
-      RUST: 1.5.0
+      RUST: 1.9.0
     - TOOLCHAIN_VERSION: 12.0
       RUST: beta
     - TOOLCHAIN_VERSION: 12.0

--- a/rust-certitude/src/lib.rs
+++ b/rust-certitude/src/lib.rs
@@ -133,18 +133,4 @@ mod test {
         let valid = validate_cert_chain(&chain, "self-signed.badssl.com");
         assert_eq!(valid, ValidationResult::NotTrusted);
     }
-
-    #[test]
-    fn test_fails_on_invalid_asn1() {
-        // We need to mutate the first byte of the original cert.
-        let mut chain = certifi_chain();
-        let mut first_chain = chain[0].to_vec();
-        first_chain[0] = 0xff;
-        let mut chain_builder = vec![first_chain.as_slice()];
-        chain_builder.append(&mut chain[1..].to_vec());
-        let new_chain = chain_builder.as_slice();
-
-        let valid = validate_cert_chain(&new_chain, "certifi.io");
-        assert_eq!(valid, ValidationResult::NotTrusted);
-    }
 }

--- a/rust-certitude/src/lib.rs
+++ b/rust-certitude/src/lib.rs
@@ -133,4 +133,18 @@ mod test {
         let valid = validate_cert_chain(&chain, "self-signed.badssl.com");
         assert_eq!(valid, ValidationResult::NotTrusted);
     }
+
+    #[test]
+    fn test_fails_on_invalid_asn1() {
+        // We need to mutate the first byte of the original cert.
+        let mut chain = certifi_chain();
+        let mut first_chain = chain[0].to_vec();
+        first_chain[0] = 0xff;
+        let mut chain_builder = vec![first_chain.as_slice()];
+        chain_builder.append(&mut chain[1..].to_vec());
+        let new_chain = chain_builder.as_slice();
+
+        let valid = validate_cert_chain(&new_chain, "certifi.io");
+        assert_eq!(valid, ValidationResult::NotTrusted);
+    }
 }

--- a/rust-certitude/src/osx.rs
+++ b/rust-certitude/src/osx.rs
@@ -38,7 +38,7 @@ pub fn validate_cert_chain(encoded_certs: &[&[u8]], hostname: &str) -> Validatio
 // Convert a TrustResult to a ValidationResult.
 fn trust_result_to_validation_result(trust_result: TrustResult) -> ValidationResult {
     match trust_result {
-        TrustResult::Invalid | TrustResult::Unspecified => ValidationResult::Trusted,
+        TrustResult::Proceed | TrustResult::Unspecified => ValidationResult::Trusted,
         _ => ValidationResult::NotTrusted,
     }
 }

--- a/rust-certitude/src/osx.rs
+++ b/rust-certitude/src/osx.rs
@@ -114,4 +114,18 @@ mod test {
         let valid = validate_cert_chain(&chain, "self-signed.badssl.com");
         assert_eq!(valid, ValidationResult::NotTrusted);
     }
+
+    #[test]
+    fn test_fails_on_invalid_asn1() {
+        // We need to mutate the first byte of the original cert.
+        let mut chain = certifi_chain();
+        let mut first_chain = chain[0].to_vec();
+        first_chain[0] = 0xff;
+        let mut chain_builder = vec![first_chain.as_slice()];
+        chain_builder.append(&mut chain[1..].to_vec());
+        let new_chain = chain_builder.as_slice();
+
+        let valid = validate_cert_chain(&new_chain, "certifi.io");
+        assert_eq!(valid, ValidationResult::NotTrusted);
+    }
 }

--- a/rust-certitude/src/windows.rs
+++ b/rust-certitude/src/windows.rs
@@ -306,6 +306,6 @@ mod test {
         let new_chain = chain_builder.as_slice();
 
         let valid = validate_cert_chain(&new_chain, "certifi.io");
-        assert_eq!(valid, ValidationResult::NotTrusted);
+        assert_eq!(valid, ValidationResult::MalformedCertificateInChain);
     }
 }

--- a/rust-certitude/src/windows.rs
+++ b/rust-certitude/src/windows.rs
@@ -294,4 +294,18 @@ mod test {
         let valid = validate_cert_chain(&chain, "self-signed.badssl.com");
         assert_eq!(valid, ValidationResult::NotTrusted);
     }
+
+    #[test]
+    fn test_fails_on_invalid_asn1() {
+        // We need to mutate the first byte of the original cert.
+        let mut chain = certifi_chain();
+        let mut first_chain = chain[0].to_vec();
+        first_chain[0] = 0xff;
+        let mut chain_builder = vec![first_chain.as_slice()];
+        chain_builder.append(&mut chain[1..].to_vec());
+        let new_chain = chain_builder.as_slice();
+
+        let valid = validate_cert_chain(&new_chain, "certifi.io");
+        assert_eq!(valid, ValidationResult::NotTrusted);
+    }
 }


### PR DESCRIPTION
Turns out on OS X we'd trust the Invalid return code, but not the Proceed return code. I haven't found a way that Invalid can actually be returned, so I don't think this was a security hole, but it's pretty dumb that if you explicitly trusted a root we would refuse to trust it.

This is an indication that we need a better test suite that we can run that doesn't depend on the trust settings on a individual machine.
